### PR TITLE
Don't prepend @ when plugin_type is system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Development
 
+- Fixed prepending of `@` in system config where it is invalid (@synical)
+
 ## 2021-07-07 - Release v1.1.2
 
 - Fixed Github ACtions workflow

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -22,7 +22,10 @@ module FluentConfig
           tag_pattern = plugin_config.delete(TAG_PATTERN)
           result << directive_tag(plugin_type, tag_pattern) do
             plugin_config.keys.sort.reduce('') do |body, parameter|
-              body << directive_body(parameter, plugin_config.fetch(parameter))
+              body << directive_body(
+                plugin_type == 'system' ? parameter : format_parameter(parameter),
+                plugin_config.fetch(parameter)
+              )
             end
           end
         end
@@ -49,7 +52,7 @@ module FluentConfig
       if value.is_a?(Hash) || value.is_a?(Array)
         generate(parameter => value)
       else
-        "#{format_parameter(parameter)} #{value}\n"
+        "#{parameter} #{value}\n"
       end
     end
 

--- a/lib/fluent/config.rb
+++ b/lib/fluent/config.rb
@@ -24,7 +24,7 @@ module FluentConfig
             plugin_config.keys.sort.reduce('') do |body, parameter|
               body << directive_body(
                 plugin_type == 'system' ? parameter : format_parameter(parameter),
-                plugin_config.fetch(parameter)
+                plugin_config.fetch(parameter),
               )
             end
           end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe 'fluentd::config' do
                   'mode'    => nil,
                   'require' => 'Class[Fluentd::Install]',
                   'notify'  => 'Class[Fluentd::Service]')
+            .with_content(%r{<system>})
+            .with_content(%r{^[\s]+log_level warn})
             .with_content(%r{<match \*\*>})
             .with_content(%r{@type forward})
             .with_content(%r{<server>})

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe 'fluentd::config' do
       let(:params) do
         {
           config: {
+            'system' => {
+              'log_level' => 'warn',
+            },
             'match' => {
               'tag_pattern' => '**',
               'type' => 'forward',
@@ -68,6 +71,8 @@ RSpec.describe 'fluentd::config' do
                   'mode'    => '0640',
                   'require' => 'Class[Fluentd::Install]',
                   'notify'  => 'Class[Fluentd::Service]')
+            .with_content(%r{<system>})
+            .with_content(%r{^[\s]+log_level warn})
             .with_content(%r{<match \*\*>})
             .with_content(%r{@type forward})
             .with_content(%r{<server>})


### PR DESCRIPTION
I've been using this module recently and I noticed that if I set the `log_level` parameter for system config it wouldn't have an effect on the log level of system logs.

Looking through the docs it seems that config at the system level should not be prepended with an `@`, as this is for overriding configuration at the plugin level. For example: https://docs.fluentd.org/configuration/plugin-common-parameters#log_level.

This PR updates `config.rb` so that it does not prefix any parameters at the `system` level with `@`.

I couldn't find any other way to set system config so went with the approach of updating the `config.rb` code. Not particularly experienced with Ruby, so am happy to update the implementation (or use some other mechanism for configuring the system if I'm missing something).