### PR TITLE
Add manage_config_dir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Default value: {}
 
 Default value: {}
 
+#### `manage_config_dir`
+
+Exclusively handle config files into `fluentd::conf_dir`. If `true` config files not created by puppet will be removed, default to `true`.
+
 ### Public Defines
 
 * `fluentd::config`: Generates custom configuration files.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class fluentd (
   String $config_group = $fluentd::params::config_group,
   Hash $configs = $fluentd::params::configs,
   Hash $plugins = $fluentd::params::plugins,
+  Boolean $manage_config_dir = $fluentd::params::manage_config_dir
 ) inherits fluentd::params {
   contain fluentd::install
   contain fluentd::service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,9 +13,9 @@ class fluentd::install inherits fluentd {
     owner   => $fluentd::config_owner,
     group   => $fluentd::config_group,
     mode    => $fluentd::config_path_mode,
-    recurse => true,
+    recurse => $fluentd::manage_config_dir,
     force   => true,
-    purge   => true,
+    purge   => $fluentd::manage_config_dir,
   }
 
   -> file { $fluentd::config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,4 +61,6 @@ class fluentd::params {
   $configs = {}
 
   $plugins = {}
+
+  $manage_config_dir = true
 }


### PR DESCRIPTION
If true (the default) this parameter have the same behavior as today : purge non puppet files into fluentd config_dir

If false it allow non puppet files into fluentd config_dir